### PR TITLE
chore(deps)!: migrate `@types/node` ^25.9.2 → ^26.1.1

### DIFF
--- a/internal/deps/npm.go
+++ b/internal/deps/npm.go
@@ -34,7 +34,7 @@ var npm = map[string]string{
 	"@types/cors":                    "^2.8.19",
 	"@types/express":                 "^5.0.6",
 	"@types/jsonwebtoken":            "^9.0.10",
-	"@types/node":                    "^25.9.2",
+	"@types/node":                    "^26.1.1",
 	"@types/react":                   "^19.2.17",
 	"@types/react-dom":               "^19.2.3",
 	"@types/supertest":               "^7.2.0",


### PR DESCRIPTION
## Migration: `@types/node`

`^25.9.2` → `^26.1.1`

**This breaks the existing constraint**, so it is not a routine bump — the package is signalling a breaking change. Generator code or templates may need to change alongside it.

CI will tell you: if test-flows passes as-is, this is just a version bump after all. If it fails, that failure *is* the work.

This branch is yours now — the bot will not touch it again. Leaving this PR open tells the bot you have this in hand, and keeps `@types/node` out of the Rollup.

---
🤖 [dep-checker](../tree/main/tools/dep-checker)