### PR TITLE
chore(deps)!: migrate `@asteasolutions/zod-to-openapi` ^8.5.0 → ^9.0.0

### DIFF
--- a/internal/deps/npm.go
+++ b/internal/deps/npm.go
@@ -10,7 +10,7 @@ package deps
 // and name it from a generator via deps.NPM("...").
 var npm = map[string]string{
 	"@ark-ui/react":                  "^5.37.2",
-	"@asteasolutions/zod-to-openapi": "^8.5.0",
+	"@asteasolutions/zod-to-openapi": "^9.0.0",
 	"@biomejs/biome":                 "^2.5.3",
 	"@clerk/clerk-react":             "^5.61.3",
 	"@clerk/nextjs":                  "^7.5.17",


### PR DESCRIPTION
## Migration: `@asteasolutions/zod-to-openapi`

`^8.5.0` → `^9.0.0`

**This breaks the existing constraint**, so it is not a routine bump — the package is signalling a breaking change. Generator code or templates may need to change alongside it.

CI will tell you: if test-flows passes as-is, this is just a version bump after all. If it fails, that failure *is* the work.

This branch is yours now — the bot will not touch it again. Leaving this PR open tells the bot you have this in hand, and keeps `@asteasolutions/zod-to-openapi` out of the Rollup.

---
🤖 [dep-checker](../tree/main/tools/dep-checker)