### PR TITLE
chore(deps)!: migrate `@testing-library/jest-dom` ^6.9.1 → ^7.0.0

### DIFF
--- a/internal/deps/npm.go
+++ b/internal/deps/npm.go
@@ -27,7 +27,7 @@ var npm = map[string]string{
 	"@tanstack/react-query-devtools": "^5.101.2",
 	"@tanstack/react-router":         "^1.170.17",
 	"@tanstack/router-plugin":        "^1.168.19",
-	"@testing-library/jest-dom":      "^6.9.1",
+	"@testing-library/jest-dom":      "^7.0.0",
 	"@testing-library/react":         "^16.3.2",
 	"@testing-library/user-event":    "^14.6.1",
 	"@types/cookie-parser":           "^1.4.10",


### PR DESCRIPTION
## Migration: `@testing-library/jest-dom`

`^6.9.1` → `^7.0.0`

**This breaks the existing constraint**, so it is not a routine bump — the package is signalling a breaking change. Generator code or templates may need to change alongside it.

CI will tell you: if test-flows passes as-is, this is just a version bump after all. If it fails, that failure *is* the work.

This branch is yours now — the bot will not touch it again. Leaving this PR open tells the bot you have this in hand, and keeps `@testing-library/jest-dom` out of the Rollup.

---
🤖 [dep-checker](../tree/main/tools/dep-checker)