### PR TITLE
chore(deps)!: migrate `jsdom` ^29.1.1 → ^30.0.1

### DIFF
--- a/internal/deps/npm.go
+++ b/internal/deps/npm.go
@@ -57,7 +57,7 @@ var npm = map[string]string{
 	"express":                        "^5.2.1",
 	"express-rate-limit":             "^8.5.2",
 	"jotai":                          "^2.20.1",
-	"jsdom":                          "^29.1.1",
+	"jsdom":                          "^30.0.1",
 	"jsonwebtoken":                   "^9.0.3",
 	"lucide-react":                   "^1.24.0",
 	"next":                           "^16.2.10",


### PR DESCRIPTION
## Migration: `jsdom`

`^29.1.1` → `^30.0.1`

**This breaks the existing constraint**, so it is not a routine bump — the package is signalling a breaking change. Generator code or templates may need to change alongside it.

CI will tell you: if test-flows passes as-is, this is just a version bump after all. If it fails, that failure *is* the work.

This branch is yours now — the bot will not touch it again. Leaving this PR open tells the bot you have this in hand, and keeps `jsdom` out of the Rollup.

---
🤖 [dep-checker](../tree/main/tools/dep-checker)